### PR TITLE
mark-devkit: Bump sys-devel/clang-runtime-16.0.0

### DIFF
--- a/sys-devel/clang-runtime/clang-runtime-16.0.0.ebuild
+++ b/sys-devel/clang-runtime/clang-runtime-16.0.0.ebuild
@@ -1,0 +1,23 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit multilib-build
+
+DESCRIPTION="Meta-ebuild for clang runtime libraries"
+HOMEPAGE="https://clang.llvm.org/"
+SRC_URI=""
+
+LICENSE="metapackage"
+SLOT="$(ver_cut 1-3)"
+KEYWORDS="*"
+IUSE="+compiler-rt libcxx openmp +sanitize"
+REQUIRED_USE="sanitize? ( compiler-rt )"
+
+RDEPEND="
+	compiler-rt? (
+		~sys-libs/compiler-rt-${PV}:${SLOT}
+		sanitize? ( ~sys-libs/compiler-rt-sanitizers-${PV}:${SLOT} )
+	)
+	libcxx? ( >=sys-libs/libcxx-${PV}[${MULTILIB_USEDEP}] )
+	openmp? ( >=sys-libs/libomp-${PV}[${MULTILIB_USEDEP}] )"


### PR DESCRIPTION
Automatic bump of package sys-devel/clang-runtime-16.0.0 for branch mark-unstable by mark-bot