### PR TITLE
mark-devkit: Bump sys-libs/libcxx-16.0.6-r1

### DIFF
--- a/sys-libs/libcxx/libcxx-16.0.6-r1.ebuild
+++ b/sys-libs/libcxx/libcxx-16.0.6-r1.ebuild
@@ -105,6 +105,7 @@ gen_shared_ldscript() {
 	gen_ldscript "${deps}" > "${ED}/usr/${libdir}/libc++.so" || die
 }
 src_install() {
+	local libdir=$(get_libdir)
 	cmake_src_install
 	mv "${ED}/usr/${libdir}/libc++experimental.a" "${ED}/usr/${libdir}/libc++_static.a" || die
 	gen_shared_ldscript


### PR DESCRIPTION
Automatic bump of package sys-libs/libcxx-16.0.6-r1 for branch mark-unstable by mark-bot