### PR TITLE
mark-devkit: Bump sys-libs/compiler-rt-sanitizers-16.0.6-r1

### DIFF
--- a/sys-libs/compiler-rt-sanitizers/compiler-rt-sanitizers-16.0.6-r1.ebuild
+++ b/sys-libs/compiler-rt-sanitizers/compiler-rt-sanitizers-16.0.6-r1.ebuild
@@ -15,13 +15,13 @@ KEYWORDS="*"
 IUSE="+clang debug elibc_glibc +libfuzzer +memprof +orc +profile +xray ${SANITIZER_FLAGS[@]/#/+}"
 REQUIRED_USE="|| ( ${SANITIZER_FLAGS[*]} libfuzzer orc profile xray )
 "
-DEPEND="sys-devel/llvm
-	
-"
 BDEPEND="dev-util/cmake
 	clang? ( sys-devel/clang )
 	elibc_glibc? ( net-libs/libtirpc )
 	${PYTHON_DEPS}
+	
+"
+DEPEND="sys-devel/llvm
 	
 "
 S="${WORKDIR}/llvm-src"


### PR DESCRIPTION
Automatic bump of package sys-libs/compiler-rt-sanitizers-16.0.6-r1 for branch mark-unstable by mark-bot