### PR TITLE
mark-devkit: Bump sys-libs/libcxxabi-16.0.6-r1

### DIFF
--- a/sys-libs/libcxxabi/libcxxabi-16.0.6-r1.ebuild
+++ b/sys-libs/libcxxabi/libcxxabi-16.0.6-r1.ebuild
@@ -12,10 +12,6 @@ LICENSE="Apache-2.0-with-LLVM-exceptions UoI-NCSA BSD public-domain rc"
 SLOT="0"
 KEYWORDS="*"
 IUSE="+libunwind clang static-libs"
-DEPEND="${RDEPEND}
-	sys-devel/llvm:16
-	
-"
 BDEPEND="clang? ( sys-devel/clang:16 )
 	
 "
@@ -25,6 +21,10 @@ RDEPEND="libunwind? (
 	    sys-libs/llvm-libunwind[static-libs?]
 	  )
 	)
+	
+"
+DEPEND="${RDEPEND}
+	sys-devel/llvm:16
 	
 "
 S="${WORKDIR}/llvm-src/runtimes"


### PR DESCRIPTION
Automatic bump of package sys-libs/libcxxabi-16.0.6-r1 for branch mark-unstable by mark-bot