### PR TITLE
mark-devkit: Bump dev-python/clang-python-16.0.6-r1

### DIFF
--- a/dev-python/clang-python/clang-python-16.0.6-r1.ebuild
+++ b/dev-python/clang-python/clang-python-16.0.6-r1.ebuild
@@ -10,11 +10,11 @@ SRC_URI="https://github.com/llvm/llvm-project/releases/download/llvmorg-16.0.6/l
 LICENSE="Apache-2.0-with-LLVM-exceptions UoI-NCSA"
 SLOT="0"
 KEYWORDS="*"
-DEPEND=">=sys-devel/clang-${PV}:*
-	${PYTHON_DEPS}
+RDEPEND="${PYTHON_DEPS}
 	
 "
-RDEPEND="${PYTHON_DEPS}
+DEPEND=">=sys-devel/clang-${PV}:*
+	${PYTHON_DEPS}
 	
 "
 S="${WORKDIR}/llvm-src/clang/bindings/python"


### PR DESCRIPTION
Automatic bump of package dev-python/clang-python-16.0.6-r1 for branch mark-unstable by mark-bot