### PR TITLE
mark-devkit: Bump dev-util/lldb-16.0.6-r1

### DIFF
--- a/dev-util/lldb/lldb-16.0.6-r1.ebuild
+++ b/dev-util/lldb/lldb-16.0.6-r1.ebuild
@@ -13,9 +13,6 @@ SLOT="16"
 KEYWORDS="*"
 IUSE="debug +libedit lzma ncurses +python +xml"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
-DEPEND="${RDEPEND}
-	
-"
 BDEPEND="dev-util/cmake
 	python? ( dev-lang/swig )
 	${PYTHON_DEPS}
@@ -33,6 +30,9 @@ RDEPEND="libedit? ( dev-libs/libedit:0= )
 	xml? ( dev-libs/libxml2:= )
 	sys-devel/clang:16
 	sys-devel/llvm:16
+	
+"
+DEPEND="${RDEPEND}
 	
 "
 S="${WORKDIR}/llvm-src/lldb"


### PR DESCRIPTION
Automatic bump of package dev-util/lldb-16.0.6-r1 for branch mark-unstable by mark-bot