### PR TITLE
mark-devkit: Bump sys-libs/compiler-rt-16.0.6-r1

### DIFF
--- a/sys-libs/compiler-rt/compiler-rt-16.0.6-r1.ebuild
+++ b/sys-libs/compiler-rt/compiler-rt-16.0.6-r1.ebuild
@@ -12,12 +12,12 @@ LICENSE="Apache-2.0-with-LLVM-exceptions || ( UoI-NCSA MIT )"
 SLOT="16"
 KEYWORDS="*"
 IUSE="+clang debug"
-DEPEND="sys-devel/llvm
-	
-"
 BDEPEND="dev-util/cmake
 	clang? ( sys-devel/clang )
 	${PYTHON_DEPS}
+	
+"
+DEPEND="sys-devel/llvm
 	
 "
 S="${WORKDIR}/llvm-src"


### PR DESCRIPTION
Automatic bump of package sys-libs/compiler-rt-16.0.6-r1 for branch mark-unstable by mark-bot