### PR TITLE
mark-devkit: Bump sys-devel/lld-16.0.6-r1

### DIFF
--- a/sys-devel/lld/lld-16.0.6-r1.ebuild
+++ b/sys-devel/lld/lld-16.0.6-r1.ebuild
@@ -11,11 +11,11 @@ LICENSE="Apache-2.0-with-LLVM-exceptions UoI-NCSA"
 SLOT="16"
 KEYWORDS="*"
 IUSE="debug"
-DEPEND="${RDEPEND}
-"
 RDEPEND="~sys-devel/llvm-16.0.6
 	sys-libs/zlib:=
 	
+"
+DEPEND="${RDEPEND}
 "
 S="${WORKDIR}/llvm-src/lld"
 post_src_unpack() {


### PR DESCRIPTION
Automatic bump of package sys-devel/lld-16.0.6-r1 for branch mark-unstable by mark-bot