### PR TITLE
mark-devkit: Bump dev-util/spirv-llvm-translator-16.0.5-r1

### DIFF
--- a/dev-util/spirv-llvm-translator/spirv-llvm-translator-16.0.5-r1.ebuild
+++ b/dev-util/spirv-llvm-translator/spirv-llvm-translator-16.0.5-r1.ebuild
@@ -11,14 +11,14 @@ LICENSE="UoI-NCSA"
 SLOT="16"
 KEYWORDS="*"
 IUSE="tools clang"
+RDEPEND="sys-devel/clang:16=
+	
+"
 DEPEND="dev-util/spirv-headers
 	${RDEPEND}
 	clang? (
 	  sys-devel/clang:16=
 	)
-	
-"
-RDEPEND="sys-devel/clang:16=
 	
 "
 post_src_unpack() {


### PR DESCRIPTION
Automatic bump of package dev-util/spirv-llvm-translator-16.0.5-r1 for branch mark-unstable by mark-bot