### PR TITLE
mark-devkit: Bump dev-libs/libclc-16.0.6-r1

### DIFF
--- a/dev-libs/libclc/libclc-16.0.6-r1.ebuild
+++ b/dev-libs/libclc/libclc-16.0.6-r1.ebuild
@@ -1,4 +1,5 @@
 # Distributed under the terms of the GNU General Public License v2
+# Autogen by MARK Devkit
 
 EAPI=7
 PYTHON_COMPAT=( python3+ )


### PR DESCRIPTION
Automatic bump of package dev-libs/libclc-16.0.6-r1 for branch mark-unstable by mark-bot