### PR TITLE
mark-devkit: Bump sys-devel/llvmgold-16.0.6-r1

### DIFF
--- a/sys-devel/llvmgold/llvmgold-16.0.6-r1.ebuild
+++ b/sys-devel/llvmgold/llvmgold-16.0.6-r1.ebuild
@@ -1,4 +1,5 @@
 # Distributed under the terms of the GNU General Public License v2
+# Autogen by MARK Devkit
 
 EAPI=7
 


### PR DESCRIPTION
Automatic bump of package sys-devel/llvmgold-16.0.6-r1 for branch mark-unstable by mark-bot